### PR TITLE
fix: Resolve critical webhook PR/issue number confusion

### DIFF
--- a/scripts/auth/keep-alive-claude-max.sh
+++ b/scripts/auth/keep-alive-claude-max.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Note: set -e disabled because touch commands may fail with permission errors (expected)
+
+# Script to keep Claude Max authentication alive by performing periodic operations
+# This helps prevent session timeout by maintaining activity
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AUTH_DIR="${CLAUDE_AUTH_HOST_DIR:-${HOME}/.claude-hub}"
+LOG_FILE="$PROJECT_ROOT/logs/claude-keep-alive.log"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Create log directory if it doesn't exist
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Function to log with timestamp
+log_message() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+echo "🔄 Claude Max Keep-Alive Service"
+echo "================================="
+echo ""
+
+log_message "Starting Claude Max keep-alive check"
+
+# Check if auth directory exists
+if [ ! -d "$AUTH_DIR" ]; then
+    log_message "ERROR: Authentication directory not found: $AUTH_DIR"
+    echo -e "${RED}❌ Authentication directory not found: $AUTH_DIR${NC}"
+    exit 1
+fi
+
+# Build Docker image if needed
+if ! docker images | grep -q "claude-setup"; then
+    log_message "Building claude-setup image..."
+    docker build -f "$PROJECT_ROOT/Dockerfile.claude-setup" -t claude-setup:latest "$PROJECT_ROOT" > /dev/null 2>&1
+fi
+
+# Removed perform_keep_alive function - now using direct Claude execution instead
+
+# Track success/failure
+SUCCESS_COUNT=0
+FAILURE_COUNT=0
+
+# Perform various keep-alive operations
+echo ""
+echo "🔧 Performing keep-alive operations..."
+echo ""
+
+# 1. Execute actual Claude command to maintain session
+echo "Testing Claude session with simple command..."
+log_message "Executing Claude keep-alive command"
+
+# Create a temporary test file for Claude to read
+TEST_FILE="/tmp/claude-keepalive-test-$$"
+echo "Keep-alive test at $(date)" > "$TEST_FILE"
+
+# Run Claude with a simple command that uses the API
+# Use the actual Claude Code CLI container that has proper auth mounted
+if docker run --rm \
+    -v "${AUTH_DIR}:/home/node/.claude" \
+    -e ANTHROPIC_MODEL=claude-3-haiku-20240307 \
+    --network host \
+    ghcr.io/anthropics/claude-code:latest \
+    bash -c "echo 'What is 2+2?' | claude --no-interactive 2>/dev/null | grep -q '4'" > /dev/null 2>&1; then
+    
+    echo -e "${GREEN}✅ Claude session active - keep-alive successful${NC}"
+    log_message "SUCCESS: Claude session is active"
+    ((SUCCESS_COUNT++))
+else
+    echo -e "${RED}❌ Claude session expired or unavailable${NC}"
+    log_message "FAILED: Claude session expired or unavailable"
+    ((FAILURE_COUNT++))
+fi
+
+# Clean up test file
+rm -f "$TEST_FILE"
+
+# 2. Verify authentication files still exist
+echo "Verifying authentication files..."
+if [ -f "$AUTH_DIR/.credentials.json" ]; then
+    echo -e "${GREEN}✅ Authentication file exists${NC}"
+    log_message "SUCCESS: Auth file exists"
+    ((SUCCESS_COUNT++))
+else
+    echo -e "${RED}❌ Authentication file not found${NC}"
+    log_message "FAILED: Auth file missing"
+    ((FAILURE_COUNT++))
+fi
+
+# 3. Verify statsig directory exists and has recent files
+if [ -d "$AUTH_DIR/statsig" ]; then
+    STATSIG_FILES=$(ls -1 "$AUTH_DIR/statsig" 2>/dev/null | wc -l)
+    if [ $STATSIG_FILES -gt 0 ]; then
+        echo -e "${GREEN}✅ Statsig configuration present (${STATSIG_FILES} files)${NC}"
+        log_message "SUCCESS: Statsig check - ${STATSIG_FILES} files found"
+        ((SUCCESS_COUNT++))
+    else
+        echo -e "${YELLOW}⚠️  Statsig directory empty${NC}"
+        log_message "WARNING: Statsig directory empty"
+        ((FAILURE_COUNT++))
+    fi
+else
+    echo -e "${YELLOW}⚠️  Statsig directory missing${NC}"
+    log_message "WARNING: Statsig directory not found"
+    ((FAILURE_COUNT++))
+fi
+
+# Update authentication files timestamps
+echo ""
+echo "📝 Updating authentication timestamps..."
+
+# Touch the credentials file to update its timestamp
+if [ -f "$AUTH_DIR/.credentials.json" ]; then
+    # Try to update timestamp
+    if touch "$AUTH_DIR/.credentials.json" 2>/dev/null; then
+        echo -e "${GREEN}✅ Updated .credentials.json timestamp${NC}"
+        log_message "Updated .credentials.json timestamp"
+    else
+        echo -e "${YELLOW}⚠️  Could not update timestamp (permission denied)${NC}"
+        log_message "WARNING: Could not update .credentials.json timestamp - this is OK"
+    fi
+fi
+
+# Touch statsig files
+if [ -d "$AUTH_DIR/statsig" ]; then
+    if touch "$AUTH_DIR/statsig"/* 2>/dev/null; then
+        echo -e "${GREEN}✅ Updated statsig timestamps${NC}"
+        log_message "Updated statsig timestamps"
+    else
+        echo -e "${YELLOW}⚠️  Could not update statsig timestamps (permission denied)${NC}"
+        log_message "WARNING: Could not update statsig timestamps - this is OK"
+    fi
+fi
+
+# Summary
+echo ""
+echo "📊 Keep-Alive Summary"
+echo "====================="
+echo "Successful operations: $SUCCESS_COUNT"
+echo "Failed operations: $FAILURE_COUNT"
+
+if [ $FAILURE_COUNT -eq 0 ]; then
+    echo -e "${GREEN}✅ All keep-alive operations completed successfully${NC}"
+    log_message "Keep-alive check completed successfully ($SUCCESS_COUNT operations)"
+    EXIT_CODE=0
+elif [ $SUCCESS_COUNT -gt 0 ]; then
+    echo -e "${YELLOW}⚠️  Some operations failed, but authentication appears to be working${NC}"
+    log_message "Keep-alive check completed with warnings ($SUCCESS_COUNT successful, $FAILURE_COUNT failed)"
+    EXIT_CODE=0
+else
+    echo -e "${RED}❌ All operations failed - authentication may need to be refreshed${NC}"
+    echo ""
+    echo "Please run: ./scripts/setup/setup-claude-interactive.sh"
+    log_message "Keep-alive check failed - all operations failed"
+    EXIT_CODE=1
+fi
+
+# Show next steps
+echo ""
+echo "💡 Next Steps:"
+echo "=============="
+echo "• Check detailed status: ./scripts/auth/check-claude-max-status.sh"
+echo "• View keep-alive log: tail -f $LOG_FILE"
+echo ""
+echo "• Add to crontab for automatic keep-alive (every 6 hours):"
+echo "  crontab -e"
+echo "  0 */6 * * * $SCRIPT_DIR/keep-alive-claude-max.sh > /dev/null 2>&1"
+echo ""
+echo "• Or use systemd timer for more control:"
+echo "  See: $PROJECT_ROOT/docs/claude-max-keep-alive.md"
+
+log_message "Keep-alive script finished with exit code $EXIT_CODE"
+exit $EXIT_CODE

--- a/scripts/monitor-claude.sh
+++ b/scripts/monitor-claude.sh
@@ -1,29 +1,86 @@
 #!/bin/bash
-# Monitor currently running Claude containers
+# Monitor currently running Claude containers and authentication status
 
-echo "=== Claude Container Monitor ==="
+# Colors for better visibility
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo "=== Claude Container & Auth Monitor ==="
 echo "Time: $(date)"
 echo ""
 
-# Check for running Claude containers
-CLAUDE_CONTAINERS=$(docker ps --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}" | grep "claude-.*-rail")
+# Authentication Status Section
+echo "=== 🔐 Authentication Status ==="
+AUTH_DIR="${CLAUDE_AUTH_HOST_DIR:-${HOME}/.claude-hub}"
+if [ -f "$AUTH_DIR/.credentials.json" ]; then
+    # Get auth age
+    FILE_TIMESTAMP=$(stat -c %Y "$AUTH_DIR/.credentials.json" 2>/dev/null || echo "0")
+    if [ "$FILE_TIMESTAMP" != "0" ]; then
+        CURRENT_TIME=$(date +%s)
+        AUTH_AGE=$((CURRENT_TIME - FILE_TIMESTAMP))
+        AUTH_AGE_HOURS=$((AUTH_AGE / 3600))
+        AUTH_AGE_DAYS=$((AUTH_AGE / 86400))
+        
+        if [ $AUTH_AGE_DAYS -eq 0 ]; then
+            echo -e "${GREEN}✅ Auth Age: ${AUTH_AGE_HOURS} hours${NC}"
+        elif [ $AUTH_AGE_DAYS -lt 7 ]; then
+            HOURS_REMAINDER=$((AUTH_AGE_HOURS % 24))
+            echo -e "${GREEN}✅ Auth Age: ${AUTH_AGE_DAYS} days, ${HOURS_REMAINDER} hours${NC}"
+        elif [ $AUTH_AGE_DAYS -lt 14 ]; then
+            echo -e "${YELLOW}⚠️  Auth Age: ${AUTH_AGE_DAYS} days (getting old)${NC}"
+        else
+            echo -e "${RED}❌ Auth Age: ${AUTH_AGE_DAYS} days (needs refresh)${NC}"
+        fi
+    else
+        echo -e "${YELLOW}⚠️  Cannot determine auth age${NC}"
+    fi
+    
+    # Check last keep-alive
+    if [ -f "/home/daniel/claude-hub/logs/keep-alive-cron.log" ]; then
+        LAST_KEEPALIVE=$(tail -1 /home/daniel/claude-hub/logs/keep-alive-cron.log 2>/dev/null | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}' | head -1)
+        if [ -n "$LAST_KEEPALIVE" ]; then
+            echo "Last keep-alive: $LAST_KEEPALIVE"
+        fi
+    fi
+else
+    echo -e "${RED}❌ No authentication found${NC}"
+fi
+
+echo ""
+echo "=== 🤖 Active Claude Containers ==="
+# Check for ALL running Claude containers (not just -rail)
+CLAUDE_CONTAINERS=$(docker ps --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}" | grep "claude-" | grep -v "webhook")
 
 if [ -z "$CLAUDE_CONTAINERS" ]; then
     echo "No Claude containers currently running"
 else
-    echo "Active Claude Containers:"
     echo "$CLAUDE_CONTAINERS"
     echo ""
     
-    # Show resource usage
+    # Show resource usage for all Claude containers
     echo "Resource Usage:"
-    docker stats --no-stream $(docker ps -q --filter "name=claude-.*-rail")
+    CLAUDE_IDS=$(docker ps -q --filter "name=claude-" | grep -v webhook)
+    if [ -n "$CLAUDE_IDS" ]; then
+        docker stats --no-stream $CLAUDE_IDS 2>/dev/null || echo "Unable to get stats"
+    fi
 fi
 
 echo ""
-echo "=== Recent Claude Container History ==="
-docker ps -a --format "table {{.Names}}\t{{.Status}}\t{{.CreatedAt}}" | grep "claude-.*-rail" | head -5
+echo "=== 📜 Recent Claude Container History ==="
+# Show ALL recent Claude containers (not just -rail)
+docker ps -a --format "table {{.Names}}\t{{.Status}}\t{{.CreatedAt}}" | grep "claude-" | grep -v "webhook" | head -10
 
 echo ""
-echo "=== Webhook Container Status ==="
+echo "=== 🌐 Webhook Container Status ==="
 docker ps --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}" | grep webhook
+
+# Show webhook health
+echo ""
+HEALTH=$(curl -s http://localhost:3002/health 2>/dev/null | grep -o '"status":"ok"' || echo "")
+if [ -n "$HEALTH" ]; then
+    echo -e "${GREEN}✅ Webhook Health: OK${NC}"
+else
+    echo -e "${RED}❌ Webhook Health: Not responding${NC}"
+fi

--- a/src/providers/slack/handlers/PlanHandler.ts
+++ b/src/providers/slack/handlers/PlanHandler.ts
@@ -46,15 +46,43 @@ export class PlanHandler {
         text: `🤔 Processing your idea: "${text}"\nI'll create a detailed GitHub issue with a design document...`
       });
 
-      // Get repository info from environment or default
-      const owner = process.env.DEFAULT_GITHUB_OWNER ?? 'claude-did-this';
-      const repo = process.env.DEFAULT_GITHUB_REPO ?? 'demo-repository';
+      // Parse repository from text if it starts with owner/repo format
+      let owner: string;
+      let repo: string;
+      let ideaText = text;
+
+      // Check if text starts with a repository path (owner/repo format)
+      // Match owner/repo where both can contain letters, numbers, hyphens, underscores, and dots
+      const repoMatch = text.match(/^([\w.-]+)\/([\w.-]+)\s+(.*)/);
+
+      if (repoMatch) {
+        // Use the repository from the text
+        owner = repoMatch[1];
+        repo = repoMatch[2];
+        ideaText = repoMatch[3];
+        logger.info(`Using repository from text: ${owner}/${repo}`);
+      } else {
+        // Use default repository from environment
+        const defaultRepo = process.env.DEFAULT_GITHUB_REPO ?? 'demo-repository';
+
+        // Check if DEFAULT_GITHUB_REPO already contains owner/repo format
+        if (defaultRepo.includes('/')) {
+          // It's already a full path, split it
+          const parts = defaultRepo.split('/');
+          owner = parts[0];
+          repo = parts.slice(1).join('/'); // Handle cases with multiple slashes
+        } else {
+          // It's just a repo name, use DEFAULT_GITHUB_OWNER
+          owner = process.env.DEFAULT_GITHUB_OWNER ?? 'claude-did-this';
+          repo = defaultRepo;
+        }
+      }
 
       // Create prompt for Claude to generate a detailed design document
       const claudePrompt = `You are a senior software architect creating a detailed design document for a new feature idea.
 
 User ${user_name} from ${channel_name} channel has submitted the following idea:
-"${text}"
+"${ideaText}"
 
 Please create a comprehensive GitHub issue that includes:
 
@@ -94,7 +122,7 @@ End with a section of specific questions for the product owner to help refine re
       // Create GitHub issue
       const issue = await createIssue(owner, repo, {
         title,
-        body: `## Submitted via Slack by @${user_name}\n\n**Original Idea:** ${text}\n\n---\n\n${designDoc}`,
+        body: `## Submitted via Slack by @${user_name}\n\n**Original Idea:** ${ideaText}\n\n---\n\n${designDoc}`,
         labels: ['enhancement', 'design-document', 'needs-review']
       });
 

--- a/src/providers/slack/handlers/PlanHandler.ts
+++ b/src/providers/slack/handlers/PlanHandler.ts
@@ -1,6 +1,7 @@
 import type { WebhookContext, WebhookHandlerResponse } from '../../../types/webhook';
 import type { SlackWebhookPayload } from '../SlackWebhookProvider';
 import { createLogger } from '../../../utils/logger';
+import { parseRepositoryFromText } from '../../../utils/repositoryParser';
 import { createIssue } from '../../../services/githubService';
 import { processCommand } from '../../../services/claudeService';
 import axios from 'axios';
@@ -46,37 +47,9 @@ export class PlanHandler {
         text: `🤔 Processing your idea: "${text}"\nI'll create a detailed GitHub issue with a design document...`
       });
 
-      // Parse repository from text if it starts with owner/repo format
-      let owner: string;
-      let repo: string;
-      let ideaText = text;
-
-      // Check if text starts with a repository path (owner/repo format)
-      // Match owner/repo where both can contain letters, numbers, hyphens, underscores, and dots
-      const repoMatch = text.match(/^([\w.-]+)\/([\w.-]+)\s+(.*)/);
-
-      if (repoMatch) {
-        // Use the repository from the text
-        owner = repoMatch[1];
-        repo = repoMatch[2];
-        ideaText = repoMatch[3];
-        logger.info(`Using repository from text: ${owner}/${repo}`);
-      } else {
-        // Use default repository from environment
-        const defaultRepo = process.env.DEFAULT_GITHUB_REPO ?? 'demo-repository';
-
-        // Check if DEFAULT_GITHUB_REPO already contains owner/repo format
-        if (defaultRepo.includes('/')) {
-          // It's already a full path, split it
-          const parts = defaultRepo.split('/');
-          owner = parts[0];
-          repo = parts.slice(1).join('/'); // Handle cases with multiple slashes
-        } else {
-          // It's just a repo name, use DEFAULT_GITHUB_OWNER
-          owner = process.env.DEFAULT_GITHUB_OWNER ?? 'claude-did-this';
-          repo = defaultRepo;
-        }
-      }
+      // Parse repository from text
+      const parsed = parseRepositoryFromText(text);
+      const { owner, repo, remainingText: ideaText } = parsed;
 
       // Create prompt for Claude to generate a detailed design document
       const claudePrompt = `You are a senior software architect creating a detailed design document for a new feature idea.

--- a/src/providers/slack/handlers/TestHandler.ts
+++ b/src/providers/slack/handlers/TestHandler.ts
@@ -1,0 +1,148 @@
+import type { WebhookContext, WebhookHandlerResponse } from '../../../types/webhook';
+import type { SlackWebhookPayload } from '../SlackWebhookProvider';
+import { createLogger } from '../../../utils/logger';
+import { processCommand } from '../../../services/claudeService';
+import axios from 'axios';
+
+const logger = createLogger('TestHandler');
+
+/**
+ * Handler for /test Slack command
+ * General purpose testing and webhook acknowledgment
+ */
+export class TestHandler {
+  name = 'test_handler';
+
+  /**
+   * Check if this handler can process the event
+   */
+  canHandle(payload: SlackWebhookPayload): boolean {
+    return payload.data.command === '/test';
+  }
+
+  /**
+   * Handle the /test command
+   */
+  async handle(
+    payload: SlackWebhookPayload,
+    _context: WebhookContext
+  ): Promise<WebhookHandlerResponse> {
+    const { text, response_url, user_name, channel_name } = payload.data;
+
+    try {
+      // Parse repository from text if it contains owner/repo format
+      let repoFullName: string;
+      let commandText = text?.trim() ?? '';
+
+      // Check if text contains a repository path (owner/repo format)
+      const repoMatch = commandText.match(/^([\w-]+\/[\w-]+)\s*(.*)/);
+
+      if (repoMatch) {
+        // Use the repository from the text
+        repoFullName = repoMatch[1];
+        commandText = repoMatch[2] ?? 'webhook test acknowledgment';
+        logger.info(`Using repository from text: ${repoFullName}`);
+      } else {
+        // Use default repository from environment
+        const defaultRepo = process.env.DEFAULT_GITHUB_REPO ?? 'demo-repository';
+
+        // Check if DEFAULT_GITHUB_REPO already contains owner/repo format
+        if (defaultRepo.includes('/')) {
+          // It's already a full path, use it directly
+          repoFullName = defaultRepo;
+        } else {
+          // It's just a repo name, use DEFAULT_GITHUB_OWNER
+          const owner = process.env.DEFAULT_GITHUB_OWNER;
+
+          if (!owner) {
+            await this.respondToSlack(response_url, {
+              text: '❌ DEFAULT_GITHUB_OWNER not configured. Please specify repository as: `/test owner/repo [command]`'
+            });
+            return {
+              success: false,
+              error: 'DEFAULT_GITHUB_OWNER not configured'
+            };
+          }
+
+          repoFullName = `${owner}/${defaultRepo}`;
+        }
+
+        commandText = commandText ?? 'webhook test acknowledgment';
+        logger.info(`Using default repository: ${repoFullName}`);
+      }
+
+      // Send immediate acknowledgment to Slack
+      await this.respondToSlack(response_url, {
+        text: `🧪 Processing test command for repository: ${repoFullName}`
+      });
+
+      // Create prompt for Claude
+      const claudePrompt = `You are responding to a webhook test from Slack.
+
+User ${user_name} from ${channel_name} channel sent a test command.
+Repository: ${repoFullName}
+Command: ${commandText}
+
+Please acknowledge the test and perform the requested action if any.
+If it's just a test, create a simple acknowledgment.`;
+
+      // Process with Claude
+      const response = await processCommand({
+        repoFullName,
+        issueNumber: null,
+        command: claudePrompt,
+        operationType: 'default'
+      });
+
+      // Send success response to Slack
+      await this.respondToSlack(response_url, {
+        text: `✅ Test completed!\n\n${response.substring(0, 500)}${response.length > 500 ? '...' : ''}`
+      });
+
+      logger.info('Successfully processed test command', {
+        user: user_name,
+        repository: repoFullName,
+        command: commandText
+      });
+
+      return {
+        success: true,
+        message: 'Test command processed',
+        data: { repository: repoFullName }
+      };
+    } catch (error) {
+      logger.error('Failed to process test command', { error, text });
+
+      await this.respondToSlack(response_url, {
+        text: `❌ Test failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+      });
+
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to process test command'
+      };
+    }
+  }
+
+  /**
+   * Send response back to Slack
+   */
+  private async respondToSlack(
+    responseUrl: string | undefined,
+    message: { text: string }
+  ): Promise<void> {
+    if (!responseUrl) {
+      logger.warn('No response URL provided for Slack message');
+      return;
+    }
+
+    try {
+      await axios.post(responseUrl, message);
+    } catch (error) {
+      logger.error('Failed to send response to Slack', { error });
+    }
+  }
+}
+
+// Export singleton instance
+export const testHandler = new TestHandler();

--- a/src/services/claudeService.ts
+++ b/src/services/claudeService.ts
@@ -265,6 +265,10 @@ function createPrompt({
 - Read: Access repository files and issue content
 - GitHub: Use 'gh' CLI for label operations only
 
+**SECURITY: NEVER include sensitive data in responses:**
+- NEVER include actual tokens, API keys, or secrets in your output
+- If you encounter sensitive data, replace with [REDACTED]
+
 **Task:**
 Analyze the issue and apply appropriate labels using GitHub CLI commands. Use these categories:
 - Priority: critical, high, medium, low
@@ -292,6 +296,12 @@ Complete the auto-tagging task using only the minimal required tools.`;
 - Running in: Unattended mode
 
 **CRITICAL: You MUST work on ${isPullRequest ? 'PR' : 'Issue'} #${issueNumber} ONLY. Do NOT reference or work on any other issue or PR number.**
+
+**SECURITY: NEVER include sensitive data in responses:**
+- NEVER include actual tokens (GitHub PATs, API keys, secrets) in your responses
+- If you see tokens like ghp_*, github_pat_*, xoxb-*, sk-*, etc., replace with [REDACTED]
+- NEVER include actual passwords, credentials, or authentication data
+- When referencing sensitive data, always use placeholders like [TOKEN], [SECRET], [PASSWORD]
 
 **Important Instructions:**
 1. FIRST: Verify you're working on the correct issue by running: gh ${isPullRequest ? 'pr' : 'issue'} view ${issueNumber}

--- a/src/services/claudeService.ts
+++ b/src/services/claudeService.ts
@@ -295,6 +295,9 @@ Complete the auto-tagging task using only the minimal required tools.`;
 
 **Important Instructions:**
 1. FIRST: Verify you're working on the correct issue by running: gh ${isPullRequest ? 'pr' : 'issue'} view ${issueNumber}
+   - If this command fails or the ${isPullRequest ? 'PR' : 'issue'} doesn't exist, STOP immediately
+   - DO NOT work on any other ${isPullRequest ? 'PR' : 'issue'} as a fallback
+   - Report the error: "${isPullRequest ? 'PR' : 'Issue'} #${issueNumber} not found or inaccessible"
 2. You have full GitHub CLI access via the 'gh' command
 3. When writing code:
    - Always create a feature branch for new work
@@ -322,6 +325,12 @@ Complete the auto-tagging task using only the minimal required tools.`;
 ${command}
 
 **REMINDER: You are working on ${isPullRequest ? 'PR' : 'Issue'} #${issueNumber} ONLY. Do not reference or work on any other PR or issue numbers.**
+
+**CRITICAL ERROR HANDLING:**
+- If ${isPullRequest ? 'PR' : 'Issue'} #${issueNumber} cannot be accessed, you MUST report the error
+- NEVER fall back to working on a different ${isPullRequest ? 'PR' : 'issue'}
+- NEVER say "Since I cannot access X, I'll work on Y instead"
+- If you cannot complete the requested task, explain why and stop
 
 Please complete this task fully and autonomously.`;
   }

--- a/src/services/claudeService.ts
+++ b/src/services/claudeService.ts
@@ -291,9 +291,12 @@ Complete the auto-tagging task using only the minimal required tools.`;
 - Current Branch: ${branchName ?? 'main'}
 - Running in: Unattended mode
 
+**CRITICAL: You MUST work on ${isPullRequest ? 'PR' : 'Issue'} #${issueNumber} ONLY. Do NOT reference or work on any other issue or PR number.**
+
 **Important Instructions:**
-1. You have full GitHub CLI access via the 'gh' command
-2. When writing code:
+1. FIRST: Verify you're working on the correct issue by running: gh ${isPullRequest ? 'pr' : 'issue'} view ${issueNumber}
+2. You have full GitHub CLI access via the 'gh' command
+3. When writing code:
    - Always create a feature branch for new work
    - Make commits with descriptive messages
    - Push your work to the remote repository
@@ -317,6 +320,8 @@ Complete the auto-tagging task using only the minimal required tools.`;
 
 **User Request:**
 ${command}
+
+**REMINDER: You are working on ${isPullRequest ? 'PR' : 'Issue'} #${issueNumber} ONLY. Do not reference or work on any other PR or issue numbers.**
 
 Please complete this task fully and autonomously.`;
   }

--- a/src/utils/repositoryParser.ts
+++ b/src/utils/repositoryParser.ts
@@ -1,0 +1,96 @@
+/**
+ * Utility for parsing repository information from text
+ */
+
+import { createLogger } from './logger';
+
+const logger = createLogger('repositoryParser');
+
+export interface ParsedRepository {
+  owner: string;
+  repo: string;
+  remainingText: string;
+  isExplicit: boolean; // true if explicitly provided in text, false if using defaults
+}
+
+/**
+ * Parse repository information from text that may start with owner/repo format
+ * @param text - The input text to parse
+ * @param defaultOwner - Default owner to use if not specified
+ * @param defaultRepo - Default repository to use if not specified
+ * @returns Parsed repository information
+ */
+export function parseRepositoryFromText(
+  text: string,
+  defaultOwner?: string,
+  defaultRepo?: string
+): ParsedRepository {
+  // Trim the input text
+  const trimmedText = text.trim();
+
+  // Enhanced regex to handle various GitHub repository name formats
+  // Supports: letters, numbers, hyphens, underscores, and dots
+  const repoMatch = trimmedText.match(/^([\w.-]+)\/([\w.-]+)(?:\s+(.*))?$/);
+
+  if (repoMatch) {
+    // Repository explicitly provided in text
+    const owner = repoMatch[1];
+    const repo = repoMatch[2];
+    const remainingText = repoMatch[3] || '';
+
+    logger.info(`Parsed explicit repository: ${owner}/${repo}`);
+
+    return {
+      owner,
+      repo,
+      remainingText: remainingText.trim(),
+      isExplicit: true
+    };
+  }
+
+  // No repository in text, use defaults
+  const defaultRepoValue = defaultRepo ?? process.env.DEFAULT_GITHUB_REPO ?? 'demo-repository';
+  const defaultOwnerValue = defaultOwner ?? process.env.DEFAULT_GITHUB_OWNER ?? 'claude-did-this';
+
+  // Check if DEFAULT_GITHUB_REPO already contains owner/repo format
+  if (defaultRepoValue.includes('/')) {
+    const parts = defaultRepoValue.split('/');
+    const owner = parts[0];
+    const repo = parts.slice(1).join('/'); // Handle cases with multiple slashes
+
+    logger.info(`Using default repository with full path: ${owner}/${repo}`);
+
+    return {
+      owner,
+      repo,
+      remainingText: trimmedText,
+      isExplicit: false
+    };
+  }
+
+  // Use separate owner and repo defaults
+  logger.info(`Using default repository: ${defaultOwnerValue}/${defaultRepoValue}`);
+
+  return {
+    owner: defaultOwnerValue,
+    repo: defaultRepoValue,
+    remainingText: trimmedText,
+    isExplicit: false
+  };
+}
+
+/**
+ * Validate repository name format
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @returns True if valid, false otherwise
+ */
+export function isValidRepository(owner: string, repo: string): boolean {
+  // GitHub repository naming rules:
+  // - Owner: alphanumeric, hyphens, single dots (not consecutive)
+  // - Repo: alphanumeric, hyphens, underscores, dots
+  const ownerRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+  const repoRegex = /^[a-zA-Z0-9._-]+$/;
+
+  return ownerRegex.test(owner) && repoRegex.test(repo);
+}

--- a/test/unit/utils/repositoryParser.test.ts
+++ b/test/unit/utils/repositoryParser.test.ts
@@ -1,0 +1,85 @@
+import { parseRepositoryFromText, isValidRepository } from '../../../src/utils/repositoryParser';
+
+describe('repositoryParser', () => {
+  describe('parseRepositoryFromText', () => {
+    it('should parse explicit owner/repo from text', () => {
+      const result = parseRepositoryFromText('DKG-Technology-LLC/the-rail some command');
+
+      expect(result.owner).toBe('DKG-Technology-LLC');
+      expect(result.repo).toBe('the-rail');
+      expect(result.remainingText).toBe('some command');
+      expect(result.isExplicit).toBe(true);
+    });
+
+    it('should handle repos with dots and underscores', () => {
+      const result = parseRepositoryFromText('user.name/repo_name.js test');
+
+      expect(result.owner).toBe('user.name');
+      expect(result.repo).toBe('repo_name.js');
+      expect(result.remainingText).toBe('test');
+      expect(result.isExplicit).toBe(true);
+    });
+
+    it('should handle empty remaining text', () => {
+      const result = parseRepositoryFromText('owner/repo');
+
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('repo');
+      expect(result.remainingText).toBe('');
+      expect(result.isExplicit).toBe(true);
+    });
+
+    it('should use defaults when no repo in text', () => {
+      const result = parseRepositoryFromText('just some text', 'default-owner', 'default-repo');
+
+      expect(result.owner).toBe('default-owner');
+      expect(result.repo).toBe('default-repo');
+      expect(result.remainingText).toBe('just some text');
+      expect(result.isExplicit).toBe(false);
+    });
+
+    it('should handle DEFAULT_GITHUB_REPO with full path', () => {
+      const originalRepo = process.env.DEFAULT_GITHUB_REPO;
+      process.env.DEFAULT_GITHUB_REPO = 'DKG-Technology-LLC/the-rail';
+
+      const result = parseRepositoryFromText('some command');
+
+      expect(result.owner).toBe('DKG-Technology-LLC');
+      expect(result.repo).toBe('the-rail');
+      expect(result.remainingText).toBe('some command');
+      expect(result.isExplicit).toBe(false);
+
+      // Restore
+      if (originalRepo) {
+        process.env.DEFAULT_GITHUB_REPO = originalRepo;
+      } else {
+        delete process.env.DEFAULT_GITHUB_REPO;
+      }
+    });
+
+    it('should handle repos with multiple slashes in default', () => {
+      const result = parseRepositoryFromText('test', undefined, 'owner/project/subproject');
+
+      expect(result.owner).toBe('owner');
+      expect(result.repo).toBe('project/subproject');
+      expect(result.remainingText).toBe('test');
+      expect(result.isExplicit).toBe(false);
+    });
+  });
+
+  describe('isValidRepository', () => {
+    it('should accept valid repository names', () => {
+      expect(isValidRepository('owner', 'repo')).toBe(true);
+      expect(isValidRepository('owner-123', 'repo_name')).toBe(true);
+      expect(isValidRepository('DKG-Technology-LLC', 'the-rail')).toBe(true);
+      expect(isValidRepository('user', 'repo.js')).toBe(true);
+    });
+
+    it('should reject invalid repository names', () => {
+      expect(isValidRepository('-owner', 'repo')).toBe(false);
+      expect(isValidRepository('owner-', 'repo')).toBe(false);
+      expect(isValidRepository('owner..name', 'repo')).toBe(false);
+      expect(isValidRepository('owner', '')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed Claude working on wrong PR/issue numbers (e.g., reviewing PR #424 when asked about PR #427)
- **CRITICAL**: Fixed Claude falling back to wrong PR when requested PR is inaccessible
- Fixed Slack webhook repository parsing when DEFAULT_GITHUB_REPO contains full path
- Enhanced PR/issue number enforcement in prompts

## Problem
Claude was getting confused and working on the wrong PR/issue numbers:
- **Example 1**: Asked to review PR #427, but reviewed PR #424 instead
- **Example 2**: Creating follow-up for PR #424, but referenced PR #405
- **Critical Finding**: Logs revealed Claude saying \"Since I cannot access GitHub directly to verify if PR #424 exists, I've prepared a comprehensive critical review of the most recent significant PR (#405)\" - This shows Claude was **falling back** to a different PR when it couldn't access the requested one!

## Root Cause
1. Claude was inferring PR numbers from repository context rather than using the explicitly provided issue number
2. **Worse**: When Claude couldn't access the requested PR/issue, it would silently fall back to working on a different one instead of reporting an error

## Solution
1. **Added CRITICAL instruction** to work ONLY on specified PR/issue number
2. **Added verification step** - Claude must run `gh pr/issue view` first
3. **Added fallback prevention**:
   - If requested PR/issue can't be accessed, STOP immediately
   - NEVER fall back to working on a different PR/issue
   - NEVER say \"Since I cannot access X, I'll work on Y instead\"
   - If task cannot be completed, explain why and stop
4. **Added reminder** at end of prompt to reinforce correct PR/issue
5. **Fixed Slack handler** repo parsing when DEFAULT_GITHUB_REPO contains full path

## Test Plan
- [ ] Test webhook with PR review request
- [ ] Verify Claude reviews the correct PR number
- [ ] Test with non-existent PR number - verify Claude reports error instead of falling back
- [ ] Test Slack commands with various repo formats
- [ ] Verify no prepending of owner to full repo paths

## Files Changed
- `BugHandler.ts`: Fix repo parsing, use bugText variable
- `PlanHandler.ts`: Fix repo parsing, use ideaText variable  
- `TestHandler.ts`: Add proper repo parsing logic
- `claudeService.ts`: Add strict PR/issue number constraints and fallback prevention

This should prevent Claude from reviewing or referencing wrong PRs and ensure it fails loudly rather than silently working on the wrong thing.

🤖 Generated with [Claude Code](https://claude.ai/code)